### PR TITLE
Use tensor.item() to convert 0-dim tensor to a Python number

### DIFF
--- a/train.py
+++ b/train.py
@@ -140,8 +140,8 @@ def validate(model, criterion, valset, iteration, batch_size, n_gpus,
             x, y = batch_parser(batch)
             y_pred = model(x)
             loss = criterion(y_pred, y)
-            reduced_val_loss = reduce_tensor(loss.data, n_gpus)[0] \
-                if distributed_run else loss.data[0]
+            reduced_val_loss = reduce_tensor(loss.data, n_gpus).item() \
+                if distributed_run else loss.data.item()
             val_loss += reduced_val_loss
         val_loss = val_loss / (i + 1)
 
@@ -215,8 +215,8 @@ def train(output_directory, log_directory, checkpoint_path, warm_start, n_gpus,
             x, y = batch_parser(batch)
             y_pred = model(x)
             loss = criterion(y_pred, y)
-            reduced_loss = reduce_tensor(loss.data, n_gpus)[0] \
-                if hparams.distributed_run else loss.data[0]
+            reduced_loss = reduce_tensor(loss.data, n_gpus).item() \
+                if hparams.distributed_run else loss.data.item()
 
             if hparams.fp16_run:
                 optimizer.backward(loss)


### PR DESCRIPTION
Previously the code was using the 0 index of a 0-dim tensor, which prints a deprecation warning that this will be an error in PyTorch 0.5.